### PR TITLE
Minor error fixes for performing inference

### DIFF
--- a/infer.py
+++ b/infer.py
@@ -37,12 +37,12 @@ def inference(im, model, class_list, args):
     scores = np_output[idx_sort][: args.top_k]
     # Threshold
     idx_th = scores > args.th
-    return detected_classes[idx_th], scores[idx_th], im
+    return detected_classes[idx_th], scores[idx_th], im, tensor_batch
 
 
 def display_image(im, tags, filename):
 
-    path_dest = "/results"
+    path_dest = "./results"
     if not os.path.exists(path_dest):
         os.makedirs(path_dest)
 
@@ -64,7 +64,8 @@ def main():
     # Setup model
     print('Creating and loading the model...')
     state = torch.load(args.model_path, map_location='cpu')
-    # args.num_classes = state['num_classes']
+    args.num_classes = state['num_classes']
+    print(f"Number of Classes: {args.num_classes}")
     model = create_model(args).cuda()
     model.load_state_dict(state['model'], strict=True)
     model.eval()
@@ -78,7 +79,7 @@ def main():
 
     # Inference
     print('Inference...')
-    tags, scores, im = inference(args.pic_path, model, class_list, args)
+    tags, scores, im, tensor_batch = inference(args.pic_path, model, class_list, args)
 
     # displaying image
     print('Display results...')
@@ -94,15 +95,6 @@ def main():
     loss1 = loss_func1(output, target)
     loss2 = loss_func2(output, target)
     assert abs((loss1.item() - loss2.item())) < 1e-6
-
-    # displaying image
-    print('showing image on screen...')
-    fig = plt.figure()
-    plt.imshow(im)
-    plt.axis('off')
-    plt.axis('tight')
-    # plt.rcParams["axes.titlesize"] = 10
-    plt.title("detected classes: {}".format(detected_classes))
 
     plt.show()
     print('done\n')

--- a/src/loss_functions/losses.py
+++ b/src/loss_functions/losses.py
@@ -44,7 +44,7 @@ class AsymmetricLoss(nn.Module):
             one_sided_gamma = self.gamma_pos * y + self.gamma_neg * (1 - y)
             one_sided_w = torch.pow(1 - pt, one_sided_gamma)
             if self.disable_torch_grad_focal_loss:
-                torch._C.set_grad_enabled(True)
+                torch.set_grad_enabled(True)
             loss *= one_sided_w
 
         return -loss.sum()
@@ -92,13 +92,13 @@ class AsymmetricLossOptimized(nn.Module):
         # Asymmetric Focusing
         if self.gamma_neg > 0 or self.gamma_pos > 0:
             if self.disable_torch_grad_focal_loss:
-                torch._C.set_grad_enabled(False)
+                torch.set_grad_enabled(False)
             self.xs_pos = self.xs_pos * self.targets
             self.xs_neg = self.xs_neg * self.anti_targets
             self.asymmetric_w = torch.pow(1 - self.xs_pos - self.xs_neg,
                                           self.gamma_pos * self.targets + self.gamma_neg * self.anti_targets)
             if self.disable_torch_grad_focal_loss:
-                torch._C.set_grad_enabled(True)
+                torch.set_grad_enabled(True)
             self.loss *= self.asymmetric_w
 
         return -self.loss.sum()


### PR DESCRIPTION
* Modified image destination path since current path requires root access to call `os.makedirs("/results")`.
* Returned `tensor_batch` from `inference(im, model, class_list, args)` function since it is to be used in example loss calculation.
* Removed double display of the output image.
* Replaced `torch._C.set_grad_enabled()` calls with `torch.set_grad_enabled()` since it throws following `AttributeError` with PyTorch version 1.10.1:  
> AttributeError: module 'torch._C' has no attribute 'set_grad_enabled'